### PR TITLE
Fix missing activityitem dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "header": "latest",
     "footer": "latest",
     "itinerarydaycard": "latest",
-    "activityitem": "latest",
     "travelsegmentitem": "latest",
-    "accommodationitem": "latest",
     "generaleventitem": "latest",
     "iconcomponents": "latest",
     "interactivemap": "latest"


### PR DESCRIPTION
## Summary
- remove leftover `activityitem` package from package.json

## Testing
- `npm install` *(fails: network access unavailable)*
- `git status --short`
