### PR TITLE
Add interactive map links to itinerary items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+
+package-lock.json

--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import ItineraryDayCard from './components/ItineraryDayCard';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import InteractiveMap from './components/InteractiveMap';
+import { mapLocations } from './mapLocations';
 import { LoadingSpinnerIcon, MapIcon, EyeIcon, EyeSlashIcon } from './components/IconComponents';
 
 const rawItineraryData = `
@@ -130,6 +131,7 @@ const App: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [showMap, setShowMap] = useState<boolean>(false);
+  const [selectedLocationId, setSelectedLocationId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     try {
@@ -145,6 +147,11 @@ const App: React.FC = () => {
       setIsLoading(false);
     }
   }, []);
+
+  const handleSelectLocation = (id: string) => {
+    setSelectedLocationId(id);
+    if (!showMap) setShowMap(true);
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-700 text-slate-100 flex flex-col">
@@ -164,7 +171,11 @@ const App: React.FC = () => {
 
         {showMap && (
           <div className="mb-8 p-4 bg-slate-800 rounded-lg shadow-xl">
-            <InteractiveMap />
+            <InteractiveMap
+              markers={mapLocations}
+              selectedLocationId={selectedLocationId}
+              onSelectLocation={handleSelectLocation}
+            />
           </div>
         )}
 
@@ -183,7 +194,7 @@ const App: React.FC = () => {
         {itinerary && !isLoading && !error && (
           <div className="space-y-8">
             {itinerary.days.map((day: ItineraryDayType) => (
-              <ItineraryDayCard key={day.id} day={day} />
+              <ItineraryDayCard key={day.id} day={day} onSelectLocation={handleSelectLocation} selectedLocationId={selectedLocationId} />
             ))}
           </div>
         )}
@@ -194,3 +205,4 @@ const App: React.FC = () => {
 };
 
 export default App;
+

--- a/components/AccommodationItem.tsx
+++ b/components/AccommodationItem.tsx
@@ -2,19 +2,29 @@ import React from 'react';
 import { Accommodation } from '../types';
 import { BedIcon, ClockIcon, MapPinIcon, MapPinIconAlt, InformationCircleIcon } from './IconComponents';
 import { createGoogleMapsSearchLink } from '../utils';
+import { findLocationId } from '../mapLocations';
 
 interface AccommodationItemProps {
   accommodation: Accommodation;
   time?: string;
   mainLocation?: string;
+  onSelectLocation?: (id: string) => void;
+  selectedLocationId?: string;
 }
 
-const AccommodationItem: React.FC<AccommodationItemProps> = ({ accommodation, time, mainLocation }) => {
+const AccommodationItem: React.FC<AccommodationItemProps> = ({ accommodation, time, mainLocation, onSelectLocation, selectedLocationId }) => {
   const canLinkName = accommodation.name && !accommodation.name.toLowerCase().includes("airbnb");
   const nameQuery = mainLocation && canLinkName ? `${accommodation.name}, ${mainLocation}` : accommodation.name;
+  const locationId = findLocationId(accommodation.address || nameQuery);
+  const isSelected = selectedLocationId && locationId === selectedLocationId;
 
   return (
-    <div className="bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-indigo-500">
+    <div
+      className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-indigo-500 ${isSelected ? 'ring-2 ring-indigo-400' : ''}`}
+      onClick={() => locationId && onSelectLocation?.(locationId)}
+      role={locationId ? 'button' : undefined}
+      tabIndex={locationId ? 0 : -1}
+    >
       <div className="flex items-start">
         <BedIcon className="w-6 h-6 text-indigo-400 mr-3 mt-1 flex-shrink-0" />
         <div>

--- a/components/ActivityItem.tsx
+++ b/components/ActivityItem.tsx
@@ -3,20 +3,26 @@ import { Activity } from '../types';
 import { HikeIcon, SparklesIcon, ClockIcon, ArrowUpTrayIcon, ArrowDownTrayIcon, AdjustmentsHorizontalIcon, InformationCircleIcon, MapPinIcon } from './IconComponents';
 import { createGoogleMapsSearchLink } from '../utils';
 
+import { findLocationId } from '../mapLocations';
+
 interface ActivityItemProps {
   activity: Activity;
   time?: string;
+  onSelectLocation?: (id: string) => void;
+  selectedLocationId?: string;
 }
 
-const ActivityItem: React.FC<ActivityItemProps> = ({ activity, time }) => {
+const ActivityItem: React.FC<ActivityItemProps> = ({ activity, time, onSelectLocation, selectedLocationId }) => {
   const isHike = activity.title.toLowerCase().includes('hike') || activity.difficulty || activity.distance || activity.elevationGain;
 
   let mapQuery: string | null = null;
   let mapLabel: string | null = null;
+  let locationId: string | undefined;
 
   if (activity.location) {
     mapQuery = activity.location;
     mapLabel = activity.location;
+    locationId = findLocationId(activity.location);
   } else if (activity.title) {
     let tempQuery = activity.title;
     if (tempQuery.startsWith("Hike: ")) tempQuery = tempQuery.substring(6);
@@ -42,11 +48,19 @@ const ActivityItem: React.FC<ActivityItemProps> = ({ activity, time }) => {
         mapQuery = potentialQuery;
         mapLabel = potentialQuery;
     }
+    locationId = findLocationId(potentialQuery);
   }
 
 
+  const isSelected = selectedLocationId && locationId === selectedLocationId;
+
   return (
-    <div className="bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-emerald-500">
+    <div
+      className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-emerald-500 ${isSelected ? 'ring-2 ring-emerald-400' : ''}`}
+      onClick={() => locationId && onSelectLocation?.(locationId)}
+      role={locationId ? 'button' : undefined}
+      tabIndex={locationId ? 0 : -1}
+    >
       <div className="flex items-start">
         {isHike ? <HikeIcon className="w-6 h-6 text-emerald-400 mr-3 mt-1 flex-shrink-0" /> : <SparklesIcon className="w-6 h-6 text-emerald-400 mr-3 mt-1 flex-shrink-0" />}
         <div>

--- a/components/GeneralEventItem.tsx
+++ b/components/GeneralEventItem.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import { InformationCircleIcon, ClockIcon } from './IconComponents';
 import { createGoogleMapsSearchLink } from '../utils';
+import { findLocationId } from '../mapLocations';
 
 interface GeneralEventItemProps {
   description: string;
   time?: string;
+  onSelectLocation?: (id: string) => void;
+  selectedLocationId?: string;
 }
 
-const GeneralEventItem: React.FC<GeneralEventItemProps> = ({ description, time }) => {
+const GeneralEventItem: React.FC<GeneralEventItemProps> = ({ description, time, onSelectLocation, selectedLocationId }) => {
   const addressMatch = description.match(/^(?:Destination Address|Address): (.*)/i);
   let content;
+  const locationId = findLocationId(addressMatch ? addressMatch[1] : description);
+  const isSelected = selectedLocationId && locationId === selectedLocationId;
 
   if (addressMatch && addressMatch[1]) {
     const addressLabel = description.substring(0, description.indexOf(addressMatch[1]));
@@ -33,7 +38,12 @@ const GeneralEventItem: React.FC<GeneralEventItemProps> = ({ description, time }
   }
 
   return (
-    <div className="bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-slate-500">
+    <div
+      className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 border-slate-500 ${isSelected ? 'ring-2 ring-slate-400' : ''}`}
+      onClick={() => locationId && onSelectLocation?.(locationId)}
+      role={locationId ? 'button' : undefined}
+      tabIndex={locationId ? 0 : -1}
+    >
       <div className="flex items-start">
         <InformationCircleIcon className="w-6 h-6 text-slate-400 mr-3 mt-1 flex-shrink-0" />
         <div>

--- a/components/ItineraryDayCard.tsx
+++ b/components/ItineraryDayCard.tsx
@@ -8,19 +8,21 @@ import { MapPinIcon, CalendarIcon } from './IconComponents';
 
 interface ItineraryDayCardProps {
   day: ItineraryDay;
+  onSelectLocation?: (id: string) => void;
+  selectedLocationId?: string;
 }
 
-const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day }) => {
+const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocation, selectedLocationId }) => {
   const renderEvent = (event: ItineraryEvent, index: number) => {
     switch (event.type) {
       case EventType.ACTIVITY:
-        return event.activity ? <ActivityItem key={index} activity={event.activity} time={event.time} /> : null;
+        return event.activity ? <ActivityItem key={index} activity={event.activity} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
       case EventType.TRAVEL:
-        return event.travelSegment ? <TravelSegmentItem key={index} segment={event.travelSegment} time={event.time} /> : null;
+        return event.travelSegment ? <TravelSegmentItem key={index} segment={event.travelSegment} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
       case EventType.ACCOMMODATION:
-        return event.accommodation ? <AccommodationItem key={index} accommodation={event.accommodation} time={event.time} mainLocation={day.mainLocation} /> : null;
+        return event.accommodation ? <AccommodationItem key={index} accommodation={event.accommodation} time={event.time} mainLocation={day.mainLocation} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
       case EventType.GENERAL:
-        return <GeneralEventItem key={index} description={event.description || ""} time={event.time} />;
+        return <GeneralEventItem key={index} description={event.description || ""} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} />;
       default:
         return null;
     }

--- a/components/TravelSegmentItem.tsx
+++ b/components/TravelSegmentItem.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { TravelSegment } from '../types';
 import { FlightIcon, TrainIcon, BusIcon, WalkIcon, CarIcon, ClockIcon, InformationCircleIcon, TicketIcon, BuildingLibraryIcon, MapPinIcon } from './IconComponents';
 import { createGoogleMapsSearchLink } from '../utils';
+import { findLocationId } from '../mapLocations';
 
 interface TravelSegmentItemProps {
   segment: TravelSegment;
-  time?: string; 
+  time?: string;
+  onSelectLocation?: (id: string) => void;
+  selectedLocationId?: string;
 }
 
-const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time }) => {
+const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time, onSelectLocation, selectedLocationId }) => {
   const getIcon = () => {
     switch (segment.mode) {
       case 'flight': return <FlightIcon className="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" />;
@@ -33,6 +36,9 @@ const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time }) 
     }
   }
 
+  const locationId = findLocationId(segment.to) || findLocationId(segment.from) || findLocationId(segment.details);
+  const isSelected = selectedLocationId && locationId === selectedLocationId;
+
   const LocationLink: React.FC<{location?: string; label: string}> = ({ location, label }) => {
     if (!location) return null;
     // Basic check for what might be an address vs a station/city name for slightly different styling or query
@@ -54,7 +60,12 @@ const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time }) 
 
 
   return (
-    <div className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 ${getBorderColor()}`}>
+    <div
+      className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 ${getBorderColor()} ${isSelected ? 'ring-2 ring-sky-400' : ''}`}
+      onClick={() => locationId && onSelectLocation?.(locationId)}
+      role={locationId ? 'button' : undefined}
+      tabIndex={locationId ? 0 : -1}
+    >
       <div className="flex items-start">
         {getIcon()}
         <div>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
     "accommodationitem": "/components/AccommodationItem.tsx",
     "generaleventitem": "/components/GeneralEventItem.tsx",
     "iconcomponents": "/components/IconComponents.tsx",
-    "interactivemap": "/components/InteractiveMap.tsx"
+    "interactivemap": "/components/InteractiveMap.tsx",
+    "mapLocations": "/mapLocations.ts"
   }
 }
     </script>

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -1,0 +1,33 @@
+export interface MapLocation {
+  id: string;
+  name: string;
+  position: [number, number];
+  aliases?: string[];
+  notes?: string;
+}
+
+export const mapLocations: MapLocation[] = [
+  { id: 'ber-airport', name: 'BER T1-2', position: [52.3667, 13.5033], aliases: ['ber t1-2', 'ber airport'] },
+  { id: 'hermannstrasse', name: 'Hermannstraße', position: [52.467, 13.431], aliases: ['hermannstraße'], notes: 'Last stop, Berlin ABC Ticket: €4.40' },
+  { id: 'boddinstrasse', name: 'Boddinstraße', position: [52.4793, 13.432], aliases: ['boddinstraße'] },
+  { id: 'neckarstrasse', name: 'Neckarstraße 21b', position: [52.476, 13.432], aliases: ['neckarstraße 21b'] },
+  { id: 'appenzell', name: 'Appenzell', position: [47.331, 9.409], aliases: ['appenzell'] },
+  { id: 'ebenalp', name: 'Berggasthaus Ebenalp', position: [47.2824, 9.4041], aliases: ['ebenalp'] },
+  { id: 'seealpsee', name: 'Seealpsee', position: [47.2858, 9.4046], aliases: ['seealpsee'] },
+  { id: 'meglisalp', name: 'Meglisalp', position: [47.2842, 9.4218], aliases: ['meglisalp'] },
+  { id: 'lugano', name: 'Lugano', position: [46.0037, 8.9511], aliases: ['lugano'] },
+  { id: 'menaggio', name: 'Menaggio', position: [46.0152, 9.2373], aliases: ['menaggio'] },
+  { id: 'malpensa', name: 'Milan Malpensa Airport', position: [45.6303, 8.7267], aliases: ['malpensa'] },
+];
+
+export function findLocationId(text?: string): string | undefined {
+  if (!text) return undefined;
+  const lc = text.toLowerCase();
+  const loc = mapLocations.find(l => [l.name.toLowerCase(), ...(l.aliases || [])].some(a => lc.includes(a)));
+  return loc?.id;
+}
+
+export function getLocationById(id: string): MapLocation | undefined {
+  return mapLocations.find(l => l.id === id);
+}
+


### PR DESCRIPTION
## Summary
- add mapLocations constants with coordinates
- show itinerary item highlights and send events to map
- update interactive map to pan/highlight markers
- wire App state and map integration
- ignore build artifacts
- connect map marker clicks back to itinerary list

## Testing
- `npm run build`
