### PR TITLE
Add functional weather forecast

### DIFF
--- a/components/ItineraryDayCard.tsx
+++ b/components/ItineraryDayCard.tsx
@@ -5,6 +5,7 @@ import TravelSegmentItem from './TravelSegmentItem';
 import AccommodationItem from './AccommodationItem';
 import GeneralEventItem from './GeneralEventItem';
 import { MapPinIcon, CalendarIcon } from './IconComponents';
+import WeatherForecast from './WeatherForecast';
 
 interface ItineraryDayCardProps {
   day: ItineraryDay;
@@ -46,6 +47,7 @@ const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocati
         )}
       </div>
       <div className="p-6 space-y-6">
+        <WeatherForecast location={day.mainLocation} />
         {day.events.length > 0 ? (
           day.events.map(renderEvent)
         ) : (

--- a/components/WeatherForecast.tsx
+++ b/components/WeatherForecast.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { ForecastDay, fetchForecast } from '../services/weatherService';
+
+interface WeatherForecastProps {
+  location?: string;
+}
+
+const WeatherForecast: React.FC<WeatherForecastProps> = ({ location }) => {
+  const [forecast, setForecast] = useState<ForecastDay[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!location) return;
+    let cancelled = false;
+    setForecast(null);
+    setError(null);
+    fetchForecast(location)
+      .then(data => {
+        if (!cancelled) setForecast(data);
+      })
+      .catch(e => {
+        if (!cancelled) setError('Failed to load weather');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [location]);
+
+  if (!location) return null;
+
+  if (error) {
+    return <div className="text-sm text-red-400">{error}</div>;
+  }
+
+  if (!forecast) {
+    return <div className="text-sm text-sky-200">Loading forecast...</div>;
+  }
+
+  return (
+    <div className="mt-4">
+      <h4 className="text-sm font-semibold text-sky-200 mb-1">3-Day Forecast</h4>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm text-slate-200">
+        {forecast.map((day: ForecastDay, idx: number) => (
+          <div key={idx} className="bg-slate-700/50 p-2 rounded-lg text-center">
+            <p className="font-semibold">{day.date}</p>
+            <p>{day.conditions}</p>
+            <p className="text-xs">{day.high} / {day.low}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default WeatherForecast;

--- a/index.html
+++ b/index.html
@@ -59,7 +59,9 @@
     "generaleventitem": "/components/GeneralEventItem.tsx",
     "iconcomponents": "/components/IconComponents.tsx",
     "interactivemap": "/components/InteractiveMap.tsx",
-    "mapLocations": "/mapLocations.ts"
+    "mapLocations": "/mapLocations.ts",
+    "weatherforecast": "/components/WeatherForecast.tsx",
+    "weatherService": "/services/weatherService.ts"
   }
 }
     </script>

--- a/services/weatherService.ts
+++ b/services/weatherService.ts
@@ -1,0 +1,84 @@
+export interface ForecastDay {
+  date: string;
+  conditions: string;
+  high: string;
+  low: string;
+}
+
+const weatherCodeDescriptions: Record<number, string> = {
+  0: 'Clear sky',
+  1: 'Mainly clear',
+  2: 'Partly cloudy',
+  3: 'Overcast',
+  45: 'Fog',
+  48: 'Depositing rime fog',
+  51: 'Light drizzle',
+  53: 'Moderate drizzle',
+  55: 'Dense drizzle',
+  56: 'Light freezing drizzle',
+  57: 'Heavy freezing drizzle',
+  61: 'Slight rain',
+  63: 'Moderate rain',
+  65: 'Heavy rain',
+  66: 'Light freezing rain',
+  67: 'Heavy freezing rain',
+  71: 'Slight snow fall',
+  73: 'Moderate snow fall',
+  75: 'Heavy snow fall',
+  77: 'Snow grains',
+  80: 'Slight rain showers',
+  81: 'Moderate rain showers',
+  82: 'Violent rain showers',
+  85: 'Slight snow showers',
+  86: 'Heavy snow showers',
+  95: 'Thunderstorm',
+  96: 'Thunderstorm with slight hail',
+  99: 'Thunderstorm with heavy hail'
+};
+
+function describeWeather(code: number): string {
+  return weatherCodeDescriptions[code] || 'N/A';
+}
+
+export async function fetchForecast(location: string): Promise<ForecastDay[]> {
+  // Fetch coordinates for the location
+  const geoRes = await fetch(
+    `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1&language=en&format=json`
+  );
+  const geoData = await geoRes.json();
+  if (!geoData.results || geoData.results.length === 0) {
+    throw new Error('Location not found');
+  }
+  const { latitude, longitude } = geoData.results[0];
+
+  // Determine date range for the next three days
+  const now = new Date();
+  const startDate = now.toISOString().split('T')[0];
+  const endDate = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
+
+  const weatherRes = await fetch(
+    `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto&start_date=${startDate}&end_date=${endDate}`
+  );
+  const weatherData = await weatherRes.json();
+  const daily = weatherData.daily;
+  if (!daily || !daily.time) {
+    throw new Error('No forecast data');
+  }
+
+  const days: ForecastDay[] = [];
+  for (let i = 0; i < daily.time.length && i < 3; i++) {
+    const dateStr = new Date(daily.time[i]).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric'
+    });
+    days.push({
+      date: dateStr,
+      conditions: describeWeather(daily.weathercode[i]),
+      high: `${Math.round(daily.temperature_2m_max[i])}°C`,
+      low: `${Math.round(daily.temperature_2m_min[i])}°C`
+    });
+  }
+  return days;
+}


### PR DESCRIPTION
## Summary
- fetch 3‑day weather data from Open‑Meteo
- display live forecast for each itinerary location
- clean up placeholder data

## Testing
- `npm run build`
