### PR TITLE
Fix build errors due to syntax mistakes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -153,9 +153,9 @@ function buildRouteLines(itin: Itinerary): [number, number][][] {
           lastPos = end;
         } else if (from) {
           lastPos = from.position;
-
+        }
        }
-    });
+   });
   });
   return lines;
 }

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -141,13 +141,9 @@ const transitLinesGroupRef = useRef<any>(null);
       return () => {
         navigator.geolocation.clearWatch(watchId);
         if (mapInstanceRef.current) {
- -
           if (transitLinesGroupRef.current) {
             transitLinesGroupRef.current.clearLayers();
           }
-
-
- 
           mapInstanceRef.current.remove();
           mapInstanceRef.current = null;
         }
@@ -159,7 +155,6 @@ const transitLinesGroupRef = useRef<any>(null);
   }, []); // Empty dependency array ensures this runs once on mount
 
   useEffect(() => {
-<
     if (!mapInstanceRef.current || !transitLinesGroupRef.current) return;
     const group = transitLinesGroupRef.current;
     group.clearLayers();


### PR DESCRIPTION
## Summary
- fix unbalanced braces in `buildRouteLines` helper
- clean stray characters in `InteractiveMap`
- verify that `npm run build` now succeeds

## Testing
- `npm run build`