### PR TITLE
Update Berlin arrival with Uber and airport info

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,22 +12,8 @@ import { LoadingSpinnerIcon, MapIcon, EyeIcon, EyeSlashIcon } from './components
 const rawItineraryData = `
 Day 1-2 fly to Berlin (June 14-15)
 Arrive 6pm to BER on UA 8715 (prior flight is UA 926 to FRA)
-Public-transport to Neckarstraße 21b, 12053 Berlin
-
-18:19 – board S-Bahn S45 toward Südkreuz at “BER T1-2” station (trains every 20 min).
-– Single ticket Berlin ABC (€4.40) covers the whole trip; buy at DB/BVG machines or in the BVG app.
-– Ride ~34 min.
-
-18:53 – arrive Hermannstraße (last stop). Follow “U8” signs downstairs.
-
-18:57 – board U-Bahn U8 toward Wittenau; ride 1 stop (~2 min).
-
-18:59 – arrive Boddinstraße.
-
-Walk 400 m (≈5 min): exit toward Boddinstraße, head south, turn right on Neckarstraße to 21b.
-
+Uber from BER T1-2 to Neckarstraße 21b, 12053 Berlin
 ETA at Jenn’s house: ~19:05
-
 Neckarstraße 21b, 12053 Berlin, Germany
 
 Days 2-5 hang out in berlin (June 15-18, 2 full days)

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -7,7 +7,7 @@ export interface MapLocation {
 }
 
 export const mapLocations: MapLocation[] = [
-  { id: 'ber-airport', name: 'BER T1-2', position: [52.3651, 13.5098], aliases: ['ber t1-2', 'ber airport'] },
+  { id: 'ber-airport', name: 'BER T1-2', position: [52.3651, 13.5098], aliases: ['ber t1-2', 'ber airport', 'berlin airport', 'berlin brandenburg airport', 'ber'] },
   { id: 'hermannstrasse', name: 'Hermannstraße', position: [52.4673, 13.4315], aliases: ['hermannstraße'], notes: 'Last stop, Berlin ABC Ticket: €4.40' },
   { id: 'boddinstrasse', name: 'Boddinstraße', position: [52.4800, 13.4310], aliases: ['boddinstraße'] },
   { id: 'neckarstrasse', name: 'Neckarstraße 21b', position: [52.4760, 13.4315], aliases: ['neckarstraße 21b'] },

--- a/services/itineraryParser.ts
+++ b/services/itineraryParser.ts
@@ -42,8 +42,10 @@ export function parseItinerary(text: string): Itinerary {
   const trainTransferPlatformRegex = /^Train: From your arrival platform.*?Platform\s*(\w+)\. Board.*? (IR .*?|IC \d+ toward .*?), open seating/i;
   const busTransferRegex = /^Bus: Exit the train.*?Stop\s*(\w+)\.\s*(Panorama-express BP \d+ toward .*?)(?:\s*\(mandatory free seat reservation.*?\))?/i;
   const reservationNoRegex = /^Reservation No.: (.*)/i;
-  
+
   const privateTaxiRegex = /^Private Taxi Transfer: (.*?) → (.*)/i;
+  const uberFromRegex = /^Uber from (.*?) to (.*)/i;
+  const uberToRegex = /^Uber to (.*)/i;
   const pickupAddressRegex = /^Pickup Address: (.*)/i;
   const pickupTimeRegex = /^Pickup Time: (.*)/i;
   const driverContactRegex = /^Driver Contact: (.*)/i;
@@ -311,6 +313,12 @@ export function parseItinerary(text: string): Itinerary {
             k++;
         }
         consumedLines += (k - (i+1));
+    } else if (line.match(uberFromRegex)) {
+        const match = line.match(uberFromRegex)!;
+        event = { type: EventType.TRAVEL, travelSegment: { mode: 'taxi', details: `Uber from ${match[1]} to ${match[2]}`, from: match[1], to: match[2], notes: [] }};
+    } else if (line.match(uberToRegex)) {
+        const match = line.match(uberToRegex)!;
+        event = { type: EventType.TRAVEL, travelSegment: { mode: 'taxi', details: `Uber to ${match[1]}`, to: match[1], notes: [] }};
     } else if (line.match(flightDepartureRegex)) {
         const match = line.match(flightDepartureRegex)!;
         event = { type: EventType.TRAVEL, time: match[3], travelSegment: { mode: 'flight', details: `Flight ${match[1]} from ${match[2]}`, operator: match[1].split(" ")[0], from: match[2], departureTime: match[3], notes: [] }};


### PR DESCRIPTION
## Summary
- update Berlin arrival itinerary to use Uber instead of public transit
- expand BER airport aliases for easier map lookup
- parse "Uber" lines as taxi travel in itinerary parser

## Testing
- `npm run build`