### PR TITLE
Add map pan and segment highlighting features

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -153,6 +153,8 @@ const App: React.FC = () => {
   const [showMap, setShowMap] = useState<boolean>(false);
   const [selectedLocationId, setSelectedLocationId] = useState<string | undefined>(undefined);
   const [routeLines, setRouteLines] = useState<[number, number][][]>([]);
+  const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
+  const [highlightLine, setHighlightLine] = useState<[number, number][] | null>(null);
 
   useEffect(() => {
     try {
@@ -172,12 +174,24 @@ const App: React.FC = () => {
 
   const handleSelectLocation = (id: string) => {
     setSelectedLocationId(id);
+    setHighlightLine(null);
+    if (!showMap) setShowMap(true);
+  };
+
+  const handleHighlightLine = (line: [number, number][]) => {
+    setHighlightLine(line);
+    if (!showMap) setShowMap(true);
+  };
+
+  const handleHeaderClick = () => {
+    setPanTarget([52.52, 13.405]);
+    setHighlightLine(null);
     if (!showMap) setShowMap(true);
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-700 text-slate-100 flex flex-col">
-      <Header title={itinerary?.title || "Trip Itinerary"} />
+      <Header title={itinerary?.title || "Trip Itinerary"} onClick={handleHeaderClick} />
       <main className="flex-grow container mx-auto px-4 py-8">
         <div className="mb-6 flex justify-end">
           <button
@@ -197,6 +211,8 @@ const App: React.FC = () => {
               markers={mapLocations}
               lines={routeLines}
               selectedLocationId={selectedLocationId}
+              panTo={panTarget}
+              highlightLine={highlightLine}
             />
           </div>
         )}
@@ -216,7 +232,13 @@ const App: React.FC = () => {
         {itinerary && !isLoading && !error && (
           <div className="space-y-8">
             {itinerary.days.map((day: ItineraryDayType) => (
-              <ItineraryDayCard key={day.id} day={day} onSelectLocation={handleSelectLocation} selectedLocationId={selectedLocationId} />
+              <ItineraryDayCard
+                key={day.id}
+                day={day}
+                onSelectLocation={handleSelectLocation}
+                selectedLocationId={selectedLocationId}
+                onHighlightLine={handleHighlightLine}
+              />
             ))}
           </div>
         )}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,11 +4,15 @@ import { CalendarDaysIcon } from './IconComponents';
 
 interface HeaderProps {
   title: string;
+  onClick?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ title }) => {
+const Header: React.FC<HeaderProps> = ({ title, onClick }) => {
   return (
-    <header className="bg-slate-800 shadow-2xl sticky top-0 z-50">
+    <header
+      className="bg-slate-800 shadow-2xl sticky top-0 z-50 cursor-pointer"
+      onClick={onClick}
+    >
       <div className="container mx-auto px-4 py-5 flex items-center">
         <CalendarDaysIcon className="w-10 h-10 text-sky-400 mr-4" />
         <h1 className="text-3xl font-bold text-sky-300" style={{ fontFamily: "'Roboto Slab', serif" }}>

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -10,14 +10,17 @@ interface InteractiveMapProps {
   markers?: MapLocation[];
   lines?: [number, number][][];
   selectedLocationId?: string;
+  panTo?: [number, number] | null;
+  highlightLine?: [number, number][] | null;
 }
 
-const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [], selectedLocationId }) => {
+const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [], selectedLocationId, panTo, highlightLine }) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<any>(null); // To store Leaflet map instance
   const userMarkerRef = useRef<any>(null); // To store user's location marker
   const markerMapRef = useRef<Record<string, any>>({});
-const transitLinesGroupRef = useRef<any>(null);
+  const transitLinesGroupRef = useRef<any>(null);
+  const highlightLineRef = useRef<any>(null);
   const [currentPosition, setCurrentPosition] = useState<[number, number] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLocating, setIsLocating] = useState<boolean>(true);
@@ -198,6 +201,26 @@ const transitLinesGroupRef = useRef<any>(null);
       marker.openPopup();
     }
   }, [selectedLocationId]);
+
+  useEffect(() => {
+    if (!mapInstanceRef.current) return;
+    if (panTo) {
+      mapInstanceRef.current.panTo(panTo);
+    }
+  }, [panTo]);
+
+  useEffect(() => {
+    if (!mapInstanceRef.current) return;
+    if (highlightLineRef.current) {
+      mapInstanceRef.current.removeLayer(highlightLineRef.current);
+      highlightLineRef.current = null;
+    }
+    if (highlightLine && highlightLine.length > 1) {
+      highlightLineRef.current = L.polyline(highlightLine, { color: '#f97316', weight: 5 }).addTo(mapInstanceRef.current);
+      const bounds = L.latLngBounds(highlightLine);
+      mapInstanceRef.current.fitBounds(bounds.pad(0.2));
+    }
+  }, [highlightLine]);
 
   const recenterMap = () => {
     if (mapInstanceRef.current && currentPosition) {

--- a/components/ItineraryDayCard.tsx
+++ b/components/ItineraryDayCard.tsx
@@ -11,15 +11,16 @@ interface ItineraryDayCardProps {
   day: ItineraryDay;
   onSelectLocation?: (id: string) => void;
   selectedLocationId?: string;
+  onHighlightLine?: (line: [number, number][]) => void;
 }
 
-const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocation, selectedLocationId }) => {
+const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocation, selectedLocationId, onHighlightLine }) => {
   const renderEvent = (event: ItineraryEvent, index: number) => {
     switch (event.type) {
       case EventType.ACTIVITY:
         return event.activity ? <ActivityItem key={index} activity={event.activity} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
       case EventType.TRAVEL:
-        return event.travelSegment ? <TravelSegmentItem key={index} segment={event.travelSegment} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
+        return event.travelSegment ? <TravelSegmentItem key={index} segment={event.travelSegment} time={event.time} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} onHighlightLine={onHighlightLine} /> : null;
       case EventType.ACCOMMODATION:
         return event.accommodation ? <AccommodationItem key={index} accommodation={event.accommodation} time={event.time} mainLocation={day.mainLocation} onSelectLocation={onSelectLocation} selectedLocationId={selectedLocationId} /> : null;
       case EventType.GENERAL:

--- a/components/TravelSegmentItem.tsx
+++ b/components/TravelSegmentItem.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { TravelSegment } from '../types';
 import { FlightIcon, TrainIcon, BusIcon, WalkIcon, CarIcon, ClockIcon, InformationCircleIcon, TicketIcon, BuildingLibraryIcon, MapPinIcon } from './IconComponents';
 import { createGoogleMapsSearchLink } from '../utils';
-import { findLocationId } from '../mapLocations';
+import { findLocationId, getLocationById } from '../mapLocations';
 
 interface TravelSegmentItemProps {
   segment: TravelSegment;
   time?: string;
   onSelectLocation?: (id: string) => void;
   selectedLocationId?: string;
+  onHighlightLine?: (line: [number, number][]) => void;
 }
 
-const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time, onSelectLocation, selectedLocationId }) => {
+const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time, onSelectLocation, selectedLocationId, onHighlightLine }) => {
   const getIcon = () => {
     switch (segment.mode) {
       case 'flight': return <FlightIcon className="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" />;
@@ -37,6 +38,8 @@ const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time, on
   }
 
   const locationId = findLocationId(segment.to) || findLocationId(segment.from) || findLocationId(segment.details);
+  const fromPos = getLocationById(findLocationId(segment.from) || '')?.position;
+  const toPos = getLocationById(findLocationId(segment.to) || '')?.position;
   const isSelected = selectedLocationId && locationId === selectedLocationId;
 
   const LocationLink: React.FC<{location?: string; label: string}> = ({ location, label }) => {
@@ -62,7 +65,14 @@ const TravelSegmentItem: React.FC<TravelSegmentItemProps> = ({ segment, time, on
   return (
     <div
       className={`bg-slate-700/50 p-4 rounded-lg shadow-md border-l-4 ${getBorderColor()} ${isSelected ? 'ring-2 ring-sky-400' : ''}`}
-      onClick={() => locationId && onSelectLocation?.(locationId)}
+      onClick={() => {
+        if (fromPos && toPos) {
+          onHighlightLine?.([fromPos, toPos]);
+        }
+        if (locationId) {
+          onSelectLocation?.(locationId);
+        }
+      }}
       role={locationId ? 'button' : undefined}
       tabIndex={locationId ? 0 : -1}
     >

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -9,8 +9,8 @@ export interface MapLocation {
 export const mapLocations: MapLocation[] = [
   { id: 'ber-airport', name: 'BER T1-2', position: [52.3651, 13.5098], aliases: ['ber t1-2', 'ber airport', 'berlin airport', 'berlin brandenburg airport', 'ber'] },
   { id: 'hermannstrasse', name: 'Hermannstraße', position: [52.4673, 13.4315], aliases: ['hermannstraße'], notes: 'Last stop, Berlin ABC Ticket: €4.40' },
-  { id: 'boddinstrasse', name: 'Boddinstraße', position: [52.4800, 13.4310], aliases: ['boddinstraße'] },
-  { id: 'neckarstrasse', name: 'Neckarstraße 21b', position: [52.4760, 13.4315], aliases: ['neckarstraße 21b'] },
+  { id: 'boddinstrasse', name: 'Boddinstraße', position: [52.4796, 13.4323], aliases: ['boddinstraße'] },
+  { id: 'neckarstrasse', name: 'Neckarstraße 21b', position: [52.4789, 13.4374], aliases: ['neckarstraße 21b'] },
   { id: 'berlin-sudkreuz', name: 'Berlin Südkreuz', position: [52.4753, 13.3658], aliases: ['südkreuz', 'berlin südkreuz', 'suedkreuz'] },
   { id: 'appenzell', name: 'Appenzell', position: [47.3308, 9.4088], aliases: ['appenzell'] },
   { id: 'munich-hbf', name: 'München Hbf', position: [48.1402, 11.5585], aliases: ['munich hbf', 'münchen hbf', 'munchen hbf'] },


### PR DESCRIPTION
## Summary
- allow header to trigger a map pan when clicked
- add optional pan and highlight props to `InteractiveMap`
- highlight route when clicking a travel segment
- pipe highlight callback through itinerary card
- update Berlin coordinates for Boddinstraße and Neckarstraße pins

## Testing
- `npm run build`