### PR TITLE
Fix map control overlap

### DIFF
--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -255,7 +255,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [
        <button
         onClick={recenterMap}
         disabled={!currentPosition && !isLocating}
-        className="absolute top-3 right-3 z-[1001] bg-slate-800 hover:bg-slate-700 text-white font-semibold py-2 px-3 rounded-lg shadow-lg transition-colors duration-150 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+        className="absolute bottom-3 left-3 z-[1001] bg-slate-800 hover:bg-slate-700 text-white font-semibold py-2 px-3 rounded-lg shadow-lg transition-colors duration-150 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
         title="Recenter on Me"
         aria-label="Recenter map on current location"
       >


### PR DESCRIPTION
## Summary
- move the recenter/"show live location" button to the bottom-left so it doesn't overlap the layer control

## Testing
- `npm run build`
