### PR TITLE
Add Berlin focus and marker

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -153,7 +153,6 @@ const App: React.FC = () => {
   const [showMap, setShowMap] = useState<boolean>(false);
   const [selectedLocationId, setSelectedLocationId] = useState<string | undefined>(undefined);
   const [routeLines, setRouteLines] = useState<[number, number][][]>([]);
-  const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
   const [highlightLine, setHighlightLine] = useState<[number, number][] | null>(null);
 
   useEffect(() => {
@@ -184,9 +183,7 @@ const App: React.FC = () => {
   };
 
   const handleHeaderClick = () => {
-    setPanTarget([52.52, 13.405]);
-    setHighlightLine(null);
-    if (!showMap) setShowMap(true);
+    handleSelectLocation('berlin-city');
   };
 
   return (
@@ -211,7 +208,6 @@ const App: React.FC = () => {
               markers={mapLocations}
               lines={routeLines}
               selectedLocationId={selectedLocationId}
-              panTo={panTarget}
               highlightLine={highlightLine}
             />
           </div>

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -197,7 +197,8 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [
         popupAnchor: [1, -34],
         shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png'
       }));
-      mapInstanceRef.current.setView(marker.getLatLng(), 15, { animate: true });
+      const zoom = selectedLocationId === 'berlin-city' ? 12 : 15;
+      mapInstanceRef.current.setView(marker.getLatLng(), zoom, { animate: true });
       marker.openPopup();
     }
   }, [selectedLocationId]);

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -7,10 +7,11 @@ export interface MapLocation {
 }
 
 export const mapLocations: MapLocation[] = [
+  { id: 'berlin-city', name: 'Berlin City Centre', position: [52.52, 13.405], aliases: ['berlin', 'berlin city'] },
   { id: 'ber-airport', name: 'BER T1-2', position: [52.3651, 13.5098], aliases: ['ber t1-2', 'ber airport', 'berlin airport', 'berlin brandenburg airport', 'ber'] },
   { id: 'hermannstrasse', name: 'Hermannstraße', position: [52.4673, 13.4315], aliases: ['hermannstraße'], notes: 'Last stop, Berlin ABC Ticket: €4.40' },
   { id: 'boddinstrasse', name: 'Boddinstraße', position: [52.4796, 13.4323], aliases: ['boddinstraße'] },
-  { id: 'neckarstrasse', name: 'Neckarstraße 21b', position: [52.480248, 13.434019], aliases: ['neckarstraße 21b'] },
+  { id: 'neckarstrasse-21b', name: 'Neckarstraße 21b', position: [52.480248, 13.434019], aliases: ['neckarstraße 21b'] },
   { id: 'berlin-sudkreuz', name: 'Berlin Südkreuz', position: [52.4753, 13.3658], aliases: ['südkreuz', 'berlin südkreuz', 'suedkreuz'] },
   { id: 'appenzell', name: 'Appenzell', position: [47.3308, 9.4088], aliases: ['appenzell'] },
   { id: 'munich-hbf', name: 'München Hbf', position: [48.1402, 11.5585], aliases: ['munich hbf', 'münchen hbf', 'munchen hbf'] },

--- a/src/data/itinerary.json
+++ b/src/data/itinerary.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "berlin-city",
+    "name": "Berlin City Centre",
+    "lat": 52.5200,
+    "lng": 13.4050
+  },
+  {
+    "id": "neckarstrasse-21b",
+    "name": "Neckarstraße 21b",
+    "lat": 52.4760,
+    "lng": 13.4320
+  }
+]


### PR DESCRIPTION
## Summary
- add Berlin City marker and rename Neckarstraße location id
- expose zoom level change for Berlin City in `InteractiveMap`
- clicking the header jumps the map to Berlin
- stub JSON data file with new markers

## Testing
- `npm run build`