### PR TITLE
Fix Munich station departure times

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,13 +20,13 @@ Days 2-5 hang out in berlin (June 15-18, 2 full days)
 
 Day 5 travel to Appenzell, stay there (June 18)
 Jenn booking train tickets - leave Berlin 09:40am
-Departure: Berlin Südkreuz at 09:41am (Jenn booking tickets)
+Departure: Berlin Südkreuz at 09:41AM (Jenn booking tickets)
 ICE 703, Seats: Wagon 7, Seats 123, 124, 127, 128 (2 window, 2 aisle, table seating, open coach, mobile-friendly)
 Reservation No.: 804880024364
 
-Arrival in München Hbf: 02:02pm
+Arrival in München Hbf: 02:02PM
 
-Transfer at München Hbf: Depart at 02:54pm
+Transfer at München Hbf, depart at 02:54PM
 EC 190, Seats: Wagon 4, Seats 61, 62, 63, 68 (2 window, 2 aisle, open coach)
 Reservation No.: 804880024366
 


### PR DESCRIPTION
## Summary
- adjust time formatting for Berlin->Appenzell rail segments
- ensure Munich transfer line parses correctly

## Testing
- `npm run build`
