### PR TITLE
Add Ebenalp map pin and pan support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -162,6 +162,7 @@ const App: React.FC = () => {
   const [selectedLocationId, setSelectedLocationId] = useState<string | undefined>(undefined);
   const [routeLines, setRouteLines] = useState<[number, number][][]>([]);
   const [highlightLine, setHighlightLine] = useState<[number, number][] | null>(null);
+  const [panTo, setPanTo] = useState<[number, number] | null>(null);
 
   useEffect(() => {
     try {
@@ -180,6 +181,8 @@ const App: React.FC = () => {
   }, []);
 
   const handleSelectLocation = (id: string) => {
+    const loc = getLocationById(id);
+    if (loc) setPanTo(loc.position);
     setSelectedLocationId(id);
     setHighlightLine(null);
     if (!showMap) setShowMap(true);
@@ -187,6 +190,7 @@ const App: React.FC = () => {
 
   const handleHighlightLine = (line: [number, number][]) => {
     setHighlightLine(line);
+    setPanTo(null);
     if (!showMap) setShowMap(true);
   };
 
@@ -216,6 +220,7 @@ const App: React.FC = () => {
               markers={mapLocations}
               lines={routeLines}
               selectedLocationId={selectedLocationId}
+              panTo={panTo}
               highlightLine={highlightLine}
             />
           </div>

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -18,7 +18,12 @@ export const mapLocations: MapLocation[] = [
   { id: 'herisau', name: 'Herisau', position: [47.3862, 9.2792], aliases: ['herisau'] },
   { id: 'arth-goldau', name: 'Arth-Goldau', position: [47.0481, 8.5254], aliases: ['arth-goldau', 'arth goldau'] },
   { id: 'aescher', name: 'Berggasthaus Äscher', position: [47.2843, 9.4149], aliases: ['äscher', 'aescher'] },
-  { id: 'ebenalp', name: 'Berggasthaus Ebenalp', position: [47.2867, 9.4286], aliases: ['ebenalp'] },
+  {
+    id: 'ebenalp',
+    name: 'Berggasthaus Ebenalp',
+    position: [47.2867, 9.4286],
+    aliases: ['ebenalp', 'berggasthaus ebenalp']
+  },
   { id: 'seealpsee', name: 'Seealpsee', position: [47.2698, 9.4026], aliases: ['seealpsee'] },
   { id: 'meglisalp', name: 'Meglisalp', position: [47.2559, 9.3856], aliases: ['meglisalp'] },
   { id: 'lugano', name: 'Lugano', position: [46.0055, 8.9469], aliases: ['lugano'] },


### PR DESCRIPTION
## Summary
- add alias for Berggasthaus Ebenalp in map locations
- allow itinerary events to pan map to selected location

## Testing
- `npm run build`