### PR TITLE
Add beer & food points of interest

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,11 @@ Neckarstraße 21b, 12053 Berlin, Germany
 
 Days 2-5 hang out in berlin (June 15-18, 2 full days)
 
+Beer tasting at Hops & Barley Hausbrauerei
+Beer garden at BRLO Brwhouse
+Currywurst at Konnopke’s Imbiss
+Film supplies at Fotoimpex
+
 Day 5 travel to Appenzell, stay there (June 18)
 Jenn booking train tickets - leave Berlin 09:40am
 Departure: Berlin Südkreuz at 09:41AM (Jenn booking tickets)
@@ -44,6 +49,9 @@ Notes:
 • Breakfast buffet included (8 AM – 10 AM)
 • Address : Engelgasse 4, 9050 Appenzell | ☎ +41 71 787 22 10
 • Free Wi-Fi · free self-parking · on-site restaurant (hot food all day)
+
+Tasting at Brauerei Locher
+Takeaway Siedwurst at Metzgerei Fässler
 
 June 19: Appenzell → Äscher/Ebenalp
 Route:
@@ -121,6 +129,9 @@ Notes:
 • Registration code 013145-CNI-00184 (Comune di Menaggio short-let licence)
 • Nearest parking: Autosilo Via IV Novembre (covered, €15 / day) — 250 m south of the flat
 • Grocery: Conad City supermarket, Via Caronti 35, 5-min walk
+
+Craft beer at Divino 13 bar
+Brew visit at Il Birrificio di Como
 
 Day 14 go home from Milan (June 26)
 Private Taxi Transfer: Menaggio → Milan Malpensa Airport (MXP)

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { CrosshairsIcon, InformationCircleIcon } from './IconComponents';
 import { MapLocation } from '../mapLocations';
+import { createGoogleMapsSearchLink } from '../utils';
 
 // Declare L globally for Leaflet
 declare var L: any;
@@ -90,7 +91,10 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [
         iconAnchor: [12, 41],
         popupAnchor: [1, -34],
         shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png'
-      })}).addTo(map).bindPopup(`<strong>${loc.name}</strong>${loc.notes ? '<br/>'+loc.notes : ''}`);
+      })}).addTo(map);
+      const mapsUrl = createGoogleMapsSearchLink(`${loc.position[0]},${loc.position[1]}`);
+      const popupContent = `<strong>${loc.name}</strong>${loc.notes ? '<br/>' + loc.notes : ''}<br/><a href="${mapsUrl}" target="_blank" rel="noopener noreferrer">Open in Google Maps</a>`;
+      marker.bindPopup(popupContent);
       markerMapRef.current[loc.id] = marker;
     });
 

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -36,6 +36,67 @@ export const mapLocations: MapLocation[] = [
       'via iv novembre 6',
       'this airbnb'   // extra alias from the feature branch
     ] },
+  // Berlin food & drink spots
+  {
+    id: 'hops-barley',
+    name: 'Hops & Barley Hausbrauerei',
+    position: [52.5090, 13.4606],
+    aliases: ['hops & barley', 'hops and barley', 'hops barley'],
+    notes: 'Tiny Friedrichshain brew-pub pouring its own unfiltered Märzen, plus bratwurst rolls on weekend nights'
+  },
+  {
+    id: 'brlo-gleisdreieck',
+    name: 'BRLO Brwhouse',
+    position: [52.49997, 13.37353],
+    aliases: ['brlo', 'brlo brwhouse', 'brlo gleisdreieck'],
+    notes: 'Container-built beer-garden in Park am Gleisdreieck; order the house Helles and a smoked-sausage platter'
+  },
+  {
+    id: 'konnopkes',
+    name: 'Konnopke\u2019s Imbiss',
+    position: [52.54066, 13.41219],
+    aliases: ["konnopke's", 'konnopkes', 'konnopke\u2019s imbiss'],
+    notes: 'Berlin\u2019s classic Currywurst stand under the elevated U2—cheap, quick, iconic'
+  },
+  {
+    id: 'fotoimpex',
+    name: 'Fotoimpex (analog-camera shop)',
+    position: [52.5200, 13.4049],
+    aliases: ['fotoimpex', 'fotoimpex berlin'],
+    notes: 'Your go-to for film, batteries and last-minute lens wipes before the Alps leg (store is on Alte Sch\u00F6nhauser Str. 32B)'
+  },
+
+  // Appenzell stops
+  {
+    id: 'locher-brewery',
+    name: 'Brauerei Locher AG / “Qu\u00F6llfrisch” Visitor-Centre',
+    position: [47.33099, 9.41246],
+    aliases: ['brauerei locher', 'qu\u00F6llfrisch', 'locher brewery'],
+    notes: '160-year-old brewery—30-min tasting tour daily at 10:15; pick up trail-friendly 33 cl cans'
+  },
+  {
+    id: 'faessler-butcher',
+    name: 'Metzgerei F\u00E4ssler',
+    position: [47.33173, 9.39944],
+    aliases: ['metzgerei f\u00E4ssler', 'metzgerei faessler', 'faessler'],
+    notes: 'Family butcher (since 1895) two streets from Gasthaus Hof; grab Appenzeller Siedwurst for backpack lunches'
+  },
+
+  // Lake Como area
+  {
+    id: 'divino-13',
+    name: 'Divino 13 bar (Piazza Garibaldi, Menaggio)',
+    position: [46.0172, 9.2374],
+    aliases: ['divino 13', 'divino13', 'divino bar menaggio'],
+    notes: '8 taps rotating Italian craft brews + taglieri of local salumi; perfect first-night stroll spot'
+  },
+  {
+    id: 'birrificio-como',
+    name: 'Il Birrificio di Como',
+    position: [45.79530, 8.95798],
+    aliases: ['birrificio di como', 'il birrificio di como', 'como brewery'],
+    notes: 'Lombardy\u2019s flagship brew-pub (20 km south; easy train hop). Try the “Hammer” Doppelbock with their porchetta sandwich.'
+  },
 ];
 
 export function findLocationId(text?: string): string | undefined {

--- a/services/itineraryParser.ts
+++ b/services/itineraryParser.ts
@@ -384,6 +384,8 @@ export function parseItinerary(text: string): Itinerary {
     } else if (line.startsWith("— ") || line.startsWith("(") && line.endsWith(")")) { // Informational notes
         if(currentEventContext) addNoteToContext(line);
         else event = { type: EventType.GENERAL, description: line }; // If no context, make it a general event
+    } else {
+        event = { type: EventType.ACTIVITY, activity: { title: line } };
     }
     
 


### PR DESCRIPTION
## Summary
- extend map with craft beer and food stops in Berlin, Appenzell and Lake Como
- show a Google Maps link in each map popup
- parse unknown lines in itinerary as activity entries
- list new stops in the itinerary text

## Testing
- `npm run build`