### PR TITLE
Add beer & food points of interest

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,12 @@ Neckarstraße 21b, 12053 Berlin, Germany
 
 Days 2-5 hang out in berlin (June 15-18, 2 full days)
 
+Beer tasting at Hops & Barley Hausbrauerei
+Beer garden at BRLO Brwhouse
+Currywurst at Konnopke’s Imbiss
+Film supplies at Fotoimpex
+East Side Gallery (Oberbaumbrücke end)
+
 Day 5 travel to Appenzell, stay there (June 18)
 Jenn booking train tickets - leave Berlin 09:40am
 Departure: Berlin Südkreuz at 09:41AM (Jenn booking tickets)
@@ -44,6 +50,10 @@ Notes:
 • Breakfast buffet included (8 AM – 10 AM)
 • Address : Engelgasse 4, 9050 Appenzell | ☎ +41 71 787 22 10
 • Free Wi-Fi · free self-parking · on-site restaurant (hot food all day)
+
+Tasting at Brauerei Locher
+Takeaway Siedwurst at Metzgerei Fässler
+Stroll through Landsgemeinde-platz, Appenzell
 
 June 19: Appenzell → Äscher/Ebenalp
 Route:
@@ -79,6 +89,7 @@ Overnight: Berggasthaus Meglisalp
 Dinner: 5:30pm–7:30pm
 Hot tub: 8:00pm–10:00pm
 620 CHF total for res + hotpot + breakfast (155 CHF/pp) plus extra for dinner
+Morning walk through Meglisalp hamlet
 
 June 21: Meglisalp → Appenzell
 Route:
@@ -110,9 +121,11 @@ Reservation No.: [TBA after booking]
 Arrival: Menaggio, Hotel Bellavista at 03:27pm
 
 Stay: Hotel Bellavista, Menaggio
+Sunset from Hotel Bellavista roof-terrace
 
 Days 10-14 Lake Como (June 23-26, 3 full days)
 Stay in Menaggio at this Airbnb
+Check in at Airbnb – Via IV Novembre 6
 Notes:
 • 2-bed / 2-bath lake-view apartment, sleeps 4-6 (Wi-Fi, A/C, laundry)
 • Private balcony overlooking the ferry harbour — 1-min walk to boats & Piazza Garibaldi
@@ -121,6 +134,13 @@ Notes:
 • Registration code 013145-CNI-00184 (Comune di Menaggio short-let licence)
 • Nearest parking: Autosilo Via IV Novembre (covered, €15 / day) — 250 m south of the flat
 • Grocery: Conad City supermarket, Via Caronti 35, 5-min walk
+
+Craft beer at Divino 13 bar
+Brew visit at Il Birrificio di Como
+Visit Villa Carlotta (Tremezzo)
+Morning taxi-boat to Villa del Balbianello
+Hike up to Castello di Vezio
+Dinner at Osteria il Pozzo
 
 Day 14 go home from Milan (June 26)
 Private Taxi Transfer: Menaggio → Milan Malpensa Airport (MXP)

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { CrosshairsIcon, InformationCircleIcon } from './IconComponents';
 import { MapLocation } from '../mapLocations';
+import { createGoogleMapsSearchLink } from '../utils';
 
 // Declare L globally for Leaflet
 declare var L: any;
@@ -90,7 +91,10 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({ markers = [], lines = [
         iconAnchor: [12, 41],
         popupAnchor: [1, -34],
         shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png'
-      })}).addTo(map).bindPopup(`<strong>${loc.name}</strong>${loc.notes ? '<br/>'+loc.notes : ''}`);
+      })}).addTo(map);
+      const mapsUrl = createGoogleMapsSearchLink(`${loc.position[0]},${loc.position[1]}`);
+      const popupContent = `<strong>${loc.name}</strong>${loc.notes ? '<br/>' + loc.notes : ''}<br/><a href="${mapsUrl}" target="_blank" rel="noopener noreferrer">Open in Google Maps</a>`;
+      marker.bindPopup(popupContent);
       markerMapRef.current[loc.id] = marker;
     });
 

--- a/mapLocations.ts
+++ b/mapLocations.ts
@@ -25,17 +25,135 @@ export const mapLocations: MapLocation[] = [
     aliases: ['ebenalp', 'berggasthaus ebenalp']
   },
   { id: 'seealpsee', name: 'Seealpsee', position: [47.2698, 9.4026], aliases: ['seealpsee'] },
-  { id: 'meglisalp', name: 'Meglisalp', position: [47.2559, 9.3856], aliases: ['meglisalp'] },
+  { id: 'meglisalp',
+    name: 'Meglisalp hamlet',
+    position: [47.2559, 9.3856],
+    aliases: ['meglisalp', 'meglisalp hamlet'],
+    notes: 'Early-morning mist around the 15th-century chapel and stone barns.'
+  },
   { id: 'lugano', name: 'Lugano', position: [46.0055, 8.9469], aliases: ['lugano'] },
-    { id: 'menaggio-airbnb',
+  {
+    id: 'menaggio-airbnb',
     name: 'Airbnb – Via IV Novembre 6',
-    position: [46.019874, 9.237891],
+    position: [46.0167, 9.2333],
     aliases: [
       'menaggio airbnb',
       'airbnb via iv novembre 6',
       'via iv novembre 6',
-      'this airbnb'   // extra alias from the feature branch
-    ] },
+      'this airbnb'
+    ],
+    notes: 'Your lakeside flat; pin helps the app pan straight to the door.'
+  },
+  // Berlin food & drink spots
+  {
+    id: 'hops-barley',
+    name: 'Hops & Barley Hausbrauerei',
+    position: [52.5090, 13.4606],
+    aliases: ['hops & barley', 'hops and barley', 'hops barley'],
+    notes: 'Tiny Friedrichshain brew-pub pouring its own unfiltered Märzen, plus bratwurst rolls on weekend nights'
+  },
+  {
+    id: 'brlo-gleisdreieck',
+    name: 'BRLO Brwhouse',
+    position: [52.49997, 13.37353],
+    aliases: ['brlo', 'brlo brwhouse', 'brlo gleisdreieck'],
+    notes: 'Container-built beer-garden in Park am Gleisdreieck; order the house Helles and a smoked-sausage platter'
+  },
+  {
+    id: 'konnopkes',
+    name: 'Konnopke\u2019s Imbiss',
+    position: [52.54066, 13.41219],
+    aliases: ["konnopke's", 'konnopkes', 'konnopke\u2019s imbiss'],
+    notes: 'Berlin\u2019s classic Currywurst stand under the elevated U2—cheap, quick, iconic'
+  },
+  {
+    id: 'fotoimpex',
+    name: 'Fotoimpex (analog-camera shop)',
+    position: [52.5200, 13.4049],
+    aliases: ['fotoimpex', 'fotoimpex berlin'],
+    notes: 'Your go-to for film, batteries and last-minute lens wipes before the Alps leg (store is on Alte Sch\u00F6nhauser Str. 32B)'
+  },
+  {
+    id: 'east-side-gallery',
+    name: 'East Side Gallery (Oberbaumbr\u00fccke end)',
+    position: [52.5050, 13.4396],
+    aliases: ['east side gallery', 'oberbaumbr\u00fccke end'],
+    notes: '1.3 km of Berlin-Wall murals; go at golden hour for side-lit color and Spree reflections.'
+  },
+
+  // Appenzell stops
+  {
+    id: 'locher-brewery',
+    name: 'Brauerei Locher AG / “Qu\u00F6llfrisch” Visitor-Centre',
+    position: [47.33099, 9.41246],
+    aliases: ['brauerei locher', 'qu\u00F6llfrisch', 'locher brewery'],
+    notes: '160-year-old brewery—30-min tasting tour daily at 10:15; pick up trail-friendly 33 cl cans'
+  },
+  {
+    id: 'faessler-butcher',
+    name: 'Metzgerei F\u00E4ssler',
+    position: [47.33173, 9.39944],
+    aliases: ['metzgerei f\u00E4ssler', 'metzgerei faessler', 'faessler'],
+    notes: 'Family butcher (since 1895) two streets from Gasthaus Hof; grab Appenzeller Siedwurst for backpack lunches'
+  },
+  {
+    id: 'landsgemeinde-platz',
+    name: 'Landsgemeinde-platz, Appenzell',
+    position: [47.3330, 9.4170],
+    aliases: ['landsgemeindeplatz', 'landsgemeinde-platz'],
+    notes: 'Painted fa\u00E7ades and flag-lined square\u2014classic Swiss village scene'
+  },
+
+  // Lake Como area
+  {
+    id: 'divino-13',
+    name: 'Divino 13 bar (Piazza Garibaldi, Menaggio)',
+    position: [46.0172, 9.2374],
+    aliases: ['divino 13', 'divino13', 'divino bar menaggio'],
+    notes: '8 taps rotating Italian craft brews + taglieri of local salumi; perfect first-night stroll spot'
+  },
+  {
+    id: 'birrificio-como',
+    name: 'Il Birrificio di Como',
+    position: [45.79530, 8.95798],
+    aliases: ['birrificio di como', 'il birrificio di como', 'como brewery'],
+    notes: 'Lombardy\u2019s flagship brew-pub (20 km south; easy train hop). Try the “Hammer” Doppelbock with their porchetta sandwich.'
+  },
+  {
+    id: 'hotel-bellavista-terrace',
+    name: 'Hotel Bellavista roof-terrace',
+    position: [46.0169, 9.2361],
+    aliases: ['hotel bellavista terrace', 'bellavista roof terrace'],
+    notes: 'Sunset panorama across Bellagio; tripod-friendly railing.'
+  },
+  {
+    id: 'villa-carlotta',
+    name: 'Villa Carlotta (Tremezzo)',
+    position: [45.9852, 9.2270],
+    aliases: ['villa carlotta'],
+    notes: 'Botanical terraces; spring azaleas frame the lake and Grigna range.'
+  },
+  {
+    id: 'villa-balbianello',
+    name: 'Villa del Balbianello',
+    position: [45.9590, 9.2015],
+    aliases: ['villa del balbianello', 'balbianello'],
+    notes: 'Star Wars & Bond film set; best reached by morning taxi-boat from Lenno.'
+  },
+  {
+    id: 'castello-di-vezio',
+    name: 'Castello di Vezio (Varenna ridge)',
+    position: [46.0065, 9.2853],
+    aliases: ['castello di vezio', 'vezio castle'],
+    notes: 'Drone-like vistas without a drone; late-day light over three lake arms.'
+  },
+  {
+    id: 'osteria-il-pozzo',
+    name: 'Osteria il Pozzo, Piazza Garibaldi',
+    position: [46.0164, 9.2372],
+    aliases: ['osteria il pozzo', 'il pozzo menaggio'],
+    notes: 'Lake-fish risotto & local Nebbiolo; candle-lit tables perfect for night street shots.'
+  },
 ];
 
 export function findLocationId(text?: string): string | undefined {

--- a/services/itineraryParser.ts
+++ b/services/itineraryParser.ts
@@ -384,6 +384,8 @@ export function parseItinerary(text: string): Itinerary {
     } else if (line.startsWith("— ") || line.startsWith("(") && line.endsWith(")")) { // Informational notes
         if(currentEventContext) addNoteToContext(line);
         else event = { type: EventType.GENERAL, description: line }; // If no context, make it a general event
+    } else {
+        event = { type: EventType.ACTIVITY, activity: { title: line } };
     }
     
 


### PR DESCRIPTION
## Summary
- extend map with craft beer and food stops in Berlin, Appenzell and Lake Como
- show a Google Maps link in each map popup
- parse unknown lines in itinerary as activity entries
- list new stops in the itinerary text

## Testing
- `npm run build`
