### PR TITLE
Add sunrise/sunset times to weather forecast

### DIFF
--- a/components/WeatherForecast.tsx
+++ b/components/WeatherForecast.tsx
@@ -45,6 +45,7 @@ const WeatherForecast: React.FC<WeatherForecastProps> = ({ location }) => {
             <p className="font-semibold">{day.date}</p>
             <p>{day.conditions}</p>
             <p className="text-xs">{day.high} / {day.low}</p>
+            <p className="text-xs">Sunrise {day.sunrise} | Sunset {day.sunset}</p>
           </div>
         ))}
       </div>

--- a/services/weatherService.ts
+++ b/services/weatherService.ts
@@ -3,6 +3,8 @@ export interface ForecastDay {
   conditions: string;
   high: string;
   low: string;
+  sunrise: string;
+  sunset: string;
 }
 
 // Local fallback data used when network requests fail
@@ -95,7 +97,7 @@ export async function fetchForecast(location: string): Promise<ForecastDay[]> {
       .split('T')[0];
 
     const weatherRes = await fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto&temperature_unit=fahrenheit&start_date=${startDate}&end_date=${endDate}`
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset&timezone=auto&temperature_unit=fahrenheit&start_date=${startDate}&end_date=${endDate}`
     );
     const weatherData = await weatherRes.json();
     const daily = weatherData.daily;
@@ -109,11 +111,21 @@ export async function fetchForecast(location: string): Promise<ForecastDay[]> {
         month: 'short',
         day: 'numeric'
       });
+      const sunriseStr = new Date(daily.sunrise[i]).toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit'
+      });
+      const sunsetStr = new Date(daily.sunset[i]).toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit'
+      });
       days.push({
         date: dateStr,
         conditions: describeWeather(daily.weathercode[i]),
         high: `${Math.round(daily.temperature_2m_max[i])}°F`,
-        low: `${Math.round(daily.temperature_2m_min[i])}°F`
+        low: `${Math.round(daily.temperature_2m_min[i])}°F`,
+        sunrise: sunriseStr,
+        sunset: sunsetStr
       });
     }
     return days;

--- a/src/data/fallbackWeather.ts
+++ b/src/data/fallbackWeather.ts
@@ -2,14 +2,14 @@ import { ForecastDay } from '../../services/weatherService';
 
 const fallbackForecasts: Record<string, ForecastDay[]> = {
   'Swiss Alps (Äscher/Ebenalp)': [
-    { date: 'Jun 20', conditions: 'Partly cloudy', high: '60°F', low: '45°F' },
-    { date: 'Jun 21', conditions: 'Mostly sunny', high: '64°F', low: '47°F' },
-    { date: 'Jun 22', conditions: 'Chance of rain', high: '58°F', low: '43°F' }
+    { date: 'Jun 20', conditions: 'Partly cloudy', high: '60°F', low: '45°F', sunrise: '5:45 AM', sunset: '8:15 PM' },
+    { date: 'Jun 21', conditions: 'Mostly sunny', high: '64°F', low: '47°F', sunrise: '5:45 AM', sunset: '8:16 PM' },
+    { date: 'Jun 22', conditions: 'Chance of rain', high: '58°F', low: '43°F', sunrise: '5:44 AM', sunset: '8:17 PM' }
   ],
   'Swiss Alps (Seealpsee/Meglisalp)': [
-    { date: 'Jun 20', conditions: 'Partly cloudy', high: '60°F', low: '45°F' },
-    { date: 'Jun 21', conditions: 'Mostly sunny', high: '64°F', low: '47°F' },
-    { date: 'Jun 22', conditions: 'Chance of rain', high: '58°F', low: '43°F' }
+    { date: 'Jun 20', conditions: 'Partly cloudy', high: '60°F', low: '45°F', sunrise: '5:45 AM', sunset: '8:15 PM' },
+    { date: 'Jun 21', conditions: 'Mostly sunny', high: '64°F', low: '47°F', sunrise: '5:45 AM', sunset: '8:16 PM' },
+    { date: 'Jun 22', conditions: 'Chance of rain', high: '58°F', low: '43°F', sunrise: '5:44 AM', sunset: '8:17 PM' }
   ],
 };
 


### PR DESCRIPTION
## Summary
- extend ForecastDay with sunrise and sunset
- fetch sunrise/sunset from API
- show sunrise and sunset in forecast UI
- update fallback weather data

## Testing
- `npm run build`