### PR TITLE
Add collapsible day card feature

### DIFF
--- a/components/IconComponents.tsx
+++ b/components/IconComponents.tsx
@@ -160,3 +160,15 @@ export const CrosshairsIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const ChevronDownIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25 12 15.75 4.5 8.25" />
+  </svg>
+);
+
+export const ChevronUpIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75 12 8.25l7.5 7.5" />
+  </svg>
+);
+

--- a/components/ItineraryDayCard.tsx
+++ b/components/ItineraryDayCard.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ItineraryDay, ItineraryEvent, EventType } from '../types';
 import ActivityItem from './ActivityItem';
 import TravelSegmentItem from './TravelSegmentItem';
 import AccommodationItem from './AccommodationItem';
 import GeneralEventItem from './GeneralEventItem';
-import { MapPinIcon, CalendarIcon } from './IconComponents';
+import { MapPinIcon, CalendarIcon, ChevronDownIcon, ChevronUpIcon } from './IconComponents';
 import WeatherForecast from './WeatherForecast';
 
 interface ItineraryDayCardProps {
@@ -15,6 +15,13 @@ interface ItineraryDayCardProps {
 }
 
 const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocation, selectedLocationId, onHighlightLine }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toggleExpanded = () => {
+    setIsExpanded(prev => !prev);
+    if (navigator?.vibrate) {
+      navigator.vibrate(10);
+    }
+  };
   const renderEvent = (event: ItineraryEvent, index: number) => {
     switch (event.type) {
       case EventType.ACTIVITY:
@@ -41,28 +48,37 @@ const ItineraryDayCard: React.FC<ItineraryDayCardProps> = ({ day, onSelectLocati
 
   return (
     <div className="bg-slate-800 shadow-xl rounded-xl overflow-hidden transform hover:scale-[1.01] transition-transform duration-300 ease-in-out">
-      <div className="p-6 bg-gradient-to-r from-sky-600 to-cyan-500">
-        <h2 className="text-2xl font-bold text-white flex items-center" style={{ fontFamily: "'Roboto Slab', serif" }}>
-           {day.id.startsWith("day_june") ? "" : day.id.replace('day','Day ').replace('_', '-')} : {day.title}
-        </h2>
-        <div className="flex items-center mt-2 text-sky-100">
-            <CalendarIcon className="w-5 h-5 mr-2" />
-            <p className="text-sm ">{day.dateRange}</p>
-        </div>
-        {day.mainLocation && (
-          <div className="flex items-center mt-1 text-sky-100">
-            <MapPinIcon className="w-5 h-5 mr-2" />
-            <p className="text-sm font-medium">{day.mainLocation}</p>
+      <button onClick={toggleExpanded} className="p-6 bg-gradient-to-r from-sky-600 to-cyan-500 w-full text-left flex justify-between items-start">
+        <div>
+          <h2 className="text-2xl font-bold text-white" style={{ fontFamily: "'Roboto Slab', serif" }}>
+             {day.id.startsWith("day_june") ? "" : day.id.replace('day','Day ').replace('_', '-')} : {day.title}
+          </h2>
+          <div className="flex items-center mt-2 text-sky-100">
+              <CalendarIcon className="w-5 h-5 mr-2" />
+              <p className="text-sm ">{day.dateRange}</p>
           </div>
-        )}
-      </div>
-      <div className="p-6 space-y-6">
-        <WeatherForecast location={day.mainLocation} />
-        {day.events.length > 0 ? (
-          day.events.map(renderEvent)
+          {day.mainLocation && (
+            <div className="flex items-center mt-1 text-sky-100">
+              <MapPinIcon className="w-5 h-5 mr-2" />
+              <p className="text-sm font-medium">{day.mainLocation}</p>
+            </div>
+          )}
+        </div>
+        {isExpanded ? (
+          <ChevronUpIcon className="w-6 h-6 text-white ml-4 mt-1" />
         ) : (
-          <p className="text-slate-400 italic">No specific events planned for this day.</p>
+          <ChevronDownIcon className="w-6 h-6 text-white ml-4 mt-1" />
         )}
+      </button>
+      <div className={`overflow-hidden transition-all ${isExpanded ? 'max-h-[1000px] p-6' : 'max-h-0 p-0'}`}>
+        <div className="space-y-6">
+          <WeatherForecast location={day.mainLocation} />
+          {day.events.length > 0 ? (
+            day.events.map(renderEvent)
+          ) : (
+            <p className="text-slate-400 italic">No specific events planned for this day.</p>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new Chevron icons
- make itinerary day cards expandable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f38bf37d48328ba82d8b7e7dc5eef