### PR TITLE
Add Berlin park pins

### DIFF
--- a/src/mapLocations.ts
+++ b/src/mapLocations.ts
@@ -11,6 +11,8 @@ export const mapLocations: MapLocation[] = [
   { id: 'ber-airport', name: 'BER T1-2', position: [52.3651, 13.5098], aliases: ['ber t1-2', 'ber airport', 'berlin airport', 'berlin brandenburg airport', 'ber'] },
   { id: 'neckarstrasse-21b', name: 'Neckarstraße 21b', position: [52.480248, 13.434019], aliases: ['neckarstraße 21b'] },
   { id: 'berlin-sudkreuz', name: 'Berlin Südkreuz', position: [52.4753, 13.3658], aliases: ['südkreuz', 'berlin südkreuz', 'suedkreuz'] },
+  { id: 'tempelhofer-feld', name: 'Tempelhofer Feld', position: [52.476, 13.395], aliases: ['tempelhofer feld'] },
+  { id: 'richardplatz', name: 'Richardplatz', position: [52.47417, 13.44582], aliases: ['richardplatz'] },
   { id: 'appenzell', name: 'Appenzell', position: [47.3308, 9.4088], aliases: ['appenzell'] },
   { id: 'gasthaus-hof', name: 'Gasthaus Hof', position: [47.330981, 9.407536], aliases: ['gasthaus hof', 'gasthof-hotel hof', 'gasthof-hotel hof ag'] },
   { id: 'munich-hbf', name: 'München Hbf', position: [48.1402, 11.5585], aliases: ['munich hbf', 'münchen hbf', 'munchen hbf'] },


### PR DESCRIPTION
## Summary
- add Tempelhofer Feld and Richardplatz markers to the map

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bb29be5dc832880ffd29cdd6fa5c9